### PR TITLE
BUG: add missing package data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     },
     package_data={
         'q2_quality_control.tests': ['data/*'],
+        'q2_quality_control': ['assets/index.html']
     },
     zip_safe=False,
 )


### PR DESCRIPTION
@nbokulich, tested pip-installing with this addition locally. If you haven't tried to install this from `setup.py` yet you wouldn't have run into this issue. 